### PR TITLE
Update to version 3.10.1

### DIFF
--- a/ecs-deploy.rb
+++ b/ecs-deploy.rb
@@ -4,9 +4,9 @@
 class EcsDeploy < Formula
   desc "Simple shell script for initiating blue-green deployments on Amazon EC2 Container Service (ECS)"
   homepage "https://github.com/silinternational/ecs-deploy"
-  url "https://github.com/silinternational/ecs-deploy/archive/3.10.0.tar.gz"
-  version "3.10.0"
-  sha256 "91674edc91281694f77cceaeeb016da965fd27a73f05aa02f9630b9b3b7135dd"
+  url "https://github.com/silinternational/ecs-deploy/archive/3.10.1.tar.gz"
+  version "3.10.1"
+  sha256 "401e93e58e6c1d3f3386a8ffc0579f29b7aa125c00573d74b792c777c72b631f"
 
   depends_on "awscli"
   depends_on "jq"


### PR DESCRIPTION
The `sha256` value is the SHA-256 sum of the tar.gz file specified in the `url` property.