### PR TITLE
Update to version 3.10.2

### DIFF
--- a/ecs-deploy.rb
+++ b/ecs-deploy.rb
@@ -6,6 +6,8 @@ class EcsDeploy < Formula
   homepage "https://github.com/silinternational/ecs-deploy"
   url "https://github.com/silinternational/ecs-deploy/archive/3.10.2.tar.gz"
   version "3.10.2"
+  # When updating the version, get a SHA-256 hash of the file at the (new) url
+  # above and use that as the new sha256 value here:
   sha256 "b697e024ab653ffad44c87fc39ba96d967d15b40ad7329549a95423a9020f722"
 
   depends_on "awscli"

--- a/ecs-deploy.rb
+++ b/ecs-deploy.rb
@@ -4,9 +4,9 @@
 class EcsDeploy < Formula
   desc "Simple shell script for initiating blue-green deployments on Amazon EC2 Container Service (ECS)"
   homepage "https://github.com/silinternational/ecs-deploy"
-  url "https://github.com/silinternational/ecs-deploy/archive/3.10.1.tar.gz"
-  version "3.10.1"
-  sha256 "401e93e58e6c1d3f3386a8ffc0579f29b7aa125c00573d74b792c777c72b631f"
+  url "https://github.com/silinternational/ecs-deploy/archive/3.10.2.tar.gz"
+  version "3.10.2"
+  sha256 "b697e024ab653ffad44c87fc39ba96d967d15b40ad7329549a95423a9020f722"
 
   depends_on "awscli"
   depends_on "jq"


### PR DESCRIPTION
### Fixed
- Update to latest release (3.10.2) of ecs-deploy
- Document how to get the new `sha256` value