### PR TITLE
Update to version 3.10.4

### DIFF
--- a/ecs-deploy.rb
+++ b/ecs-deploy.rb
@@ -4,11 +4,11 @@
 class EcsDeploy < Formula
   desc "Simple shell script for initiating blue-green deployments on Amazon EC2 Container Service (ECS)"
   homepage "https://github.com/silinternational/ecs-deploy"
-  url "https://github.com/silinternational/ecs-deploy/archive/3.10.2.tar.gz"
-  version "3.10.2"
+  url "https://github.com/silinternational/ecs-deploy/archive/refs/tags/3.10.4.tar.gz"
+  version "3.10.4"
   # When updating the version, get a SHA-256 hash of the file at the (new) url
   # above and use that as the new sha256 value here:
-  sha256 "b697e024ab653ffad44c87fc39ba96d967d15b40ad7329549a95423a9020f722"
+  sha256 "5b5283cc536142de1756b46f16ef7083cdbe72edf1a33aa7963eba077182cef5"
 
   depends_on "awscli"
   depends_on "jq"


### PR DESCRIPTION
I also changed the `url` to match the URL provided in GitHub's UI for that release (and confirmed the download is accessible at that URL).